### PR TITLE
Updated navbar and rehome to only show certain items when user is not logged in.

### DIFF
--- a/frontend/src/components/NavbarComponent.js
+++ b/frontend/src/components/NavbarComponent.js
@@ -1,42 +1,3 @@
-// import React, { useState } from 'react';
-// import { Nav, LogoImg, NavLink, Bars, NavMenu, WebsiteName } from "./Navbar/NavbarElements";
-// import { FaUserCircle } from 'react-icons/fa';
-// import Logo from "../logo/Logo.png";
-
-// const Navbar = () => {
-//   const [showDropdown, setShowDropdown] = useState(false);
-
-//   return (
-//     <>
-//       <Nav>
-//         <div className="navbar-components-container" style={{ display: 'flex', alignItems: 'center', flexDirection: 'row' }}>
-//           <LogoImg src={Logo} alt="Logo" />
-//           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-//             <WebsiteName>Animal Adopter</WebsiteName>
-//             <Bars />
-//             <div className="collapse navbar-collapse" id="navbarNav">
-//               <NavMenu style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-//                 <NavLink exact to="/" activeClassName="active" className="nav-link">Home</NavLink>
-//                 <NavLink to="/adopt" activeClassName="active" className="nav-link">Adopt</NavLink>
-//                 <NavLink to="/rehome" activeClassName="active" className="nav-link">Rehome</NavLink>
-//                 <FaUserCircle size="4em" onClick={() => setShowDropdown(!showDropdown)} style={{ position: 'absolute', right: '1%', top: '15%',color: 'white', cursor: 'pointer', marginLeft: '20px' }} />
-//               </NavMenu>
-//               {showDropdown && (
-//               <div style={{ position: 'absolute', right: '1%', top: '100%', backgroundColor: 'white', padding: '10px', borderRadius: '5px', boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)' }}>
-//                 <NavLink to="/login" activeClassName="active" className="nav-link">Login/Logout</NavLink>
-//                 <NavLink to="/profilePage" activeClassName="active" className="nav-link">Your Profile</NavLink>
-//               </div>
-//             )}
-//             </div>
-//           </div>
-//         </div>
-//       </Nav>
-//     </>
-//   );
-// };
-
-// export default Navbar;
-
 import React, { useState, useEffect } from 'react';
 import { Nav, LogoImg, NavLink, Bars, NavMenu, WebsiteName } from "./Navbar/NavbarElements";
 import { FaUserCircle } from 'react-icons/fa';
@@ -45,16 +6,35 @@ import Logo from "../logo/Logo.png";
 const Navbar = () => {
   const [showDropdown, setShowDropdown] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [username, setUsername] = useState(''); // This might not be used if you're not displaying the username in the navbar
 
   useEffect(() => {
-    const token = localStorage.getItem('token');
-    const storedUsername = localStorage.getItem('username');
-    if (token && storedUsername) {
-      setIsLoggedIn(true);
-      setUsername(storedUsername);
-    }
+    const checkLogin = () => {
+      const token = localStorage.getItem('token');
+      setIsLoggedIn(!!token);
+    };
+
+    // Polling localStorage every 1000 milliseconds (1 second)
+    const intervalId = setInterval(checkLogin, 1000);
+
+    // Listen for changes in localStorage across tabs
+    const handleStorageChange = (event) => {
+      if (event.key === 'token') {
+        checkLogin();
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+
+    // Cleanup the event listener and interval when the component unmounts
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      clearInterval(intervalId);
+    };
   }, []);
+
+  const closeDropdown = () => {
+    setShowDropdown(false);
+  };
 
   return (
     <>
@@ -66,21 +46,20 @@ const Navbar = () => {
             <Bars onClick={() => setShowDropdown(!showDropdown)} style={{ cursor: 'pointer' }} />
             <div className="collapse navbar-collapse" id="navbarNav">
               <NavMenu style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <NavLink exact to="/" activeClassName="active" className="nav-link">Home</NavLink>
-                <NavLink to="/adopt" activeClassName="active" className="nav-link">Adopt</NavLink>
-                <NavLink to="/rehome" activeClassName="active" className="nav-link">Rehome</NavLink>
+                <NavLink exact to="/" activeClassName="active" className="nav-link" onClick={closeDropdown}>Home</NavLink>
+                <NavLink to="/adopt" activeClassName="active" className="nav-link" onClick={closeDropdown}>Adopt</NavLink>
+                <NavLink to="/rehome" activeClassName="active" className="nav-link" onClick={closeDropdown}>Rehome</NavLink>
                 <FaUserCircle size="4em" onClick={() => setShowDropdown(!showDropdown)} style={{ position: 'absolute', right: '1%', top: '15%', color: 'white', cursor: 'pointer', marginLeft: '20px' }} />
               </NavMenu>
               {showDropdown && (
                 <div style={{ position: 'absolute', right: '1%', top: '100%', backgroundColor: 'white', padding: '10px', borderRadius: '5px', boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)' }}>
-                  {isLoggedIn && (
-                    <NavLink to="/login" activeClassName="active" className="nav-link">Logout</NavLink>
-                  )}
-                  {!isLoggedIn && (
-                    <NavLink to="/login" activeClassName="active" className="nav-link">Login</NavLink>
-                  )}
-                  {isLoggedIn && (
-                    <NavLink to="/profilePage" activeClassName="active" className="nav-link">Your Profile</NavLink>
+                  {isLoggedIn ? (
+                    <>
+                      <NavLink to="/profilePage" activeClassName="active" className="nav-link" onClick={closeDropdown}>Your Profile</NavLink>
+                      <NavLink to="/login" activeClassName="active" className="nav-link" onClick={closeDropdown}>Logout</NavLink>
+                    </>
+                  ) : (
+                    <NavLink to="/login" activeClassName="active" className="nav-link" onClick={closeDropdown}>Login</NavLink>
                   )}
                 </div>
               )}

--- a/frontend/src/components/NavbarComponent.js
+++ b/frontend/src/components/NavbarComponent.js
@@ -1,10 +1,60 @@
-import React, { useState } from 'react';
+// import React, { useState } from 'react';
+// import { Nav, LogoImg, NavLink, Bars, NavMenu, WebsiteName } from "./Navbar/NavbarElements";
+// import { FaUserCircle } from 'react-icons/fa';
+// import Logo from "../logo/Logo.png";
+
+// const Navbar = () => {
+//   const [showDropdown, setShowDropdown] = useState(false);
+
+//   return (
+//     <>
+//       <Nav>
+//         <div className="navbar-components-container" style={{ display: 'flex', alignItems: 'center', flexDirection: 'row' }}>
+//           <LogoImg src={Logo} alt="Logo" />
+//           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+//             <WebsiteName>Animal Adopter</WebsiteName>
+//             <Bars />
+//             <div className="collapse navbar-collapse" id="navbarNav">
+//               <NavMenu style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+//                 <NavLink exact to="/" activeClassName="active" className="nav-link">Home</NavLink>
+//                 <NavLink to="/adopt" activeClassName="active" className="nav-link">Adopt</NavLink>
+//                 <NavLink to="/rehome" activeClassName="active" className="nav-link">Rehome</NavLink>
+//                 <FaUserCircle size="4em" onClick={() => setShowDropdown(!showDropdown)} style={{ position: 'absolute', right: '1%', top: '15%',color: 'white', cursor: 'pointer', marginLeft: '20px' }} />
+//               </NavMenu>
+//               {showDropdown && (
+//               <div style={{ position: 'absolute', right: '1%', top: '100%', backgroundColor: 'white', padding: '10px', borderRadius: '5px', boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)' }}>
+//                 <NavLink to="/login" activeClassName="active" className="nav-link">Login/Logout</NavLink>
+//                 <NavLink to="/profilePage" activeClassName="active" className="nav-link">Your Profile</NavLink>
+//               </div>
+//             )}
+//             </div>
+//           </div>
+//         </div>
+//       </Nav>
+//     </>
+//   );
+// };
+
+// export default Navbar;
+
+import React, { useState, useEffect } from 'react';
 import { Nav, LogoImg, NavLink, Bars, NavMenu, WebsiteName } from "./Navbar/NavbarElements";
 import { FaUserCircle } from 'react-icons/fa';
 import Logo from "../logo/Logo.png";
 
 const Navbar = () => {
   const [showDropdown, setShowDropdown] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [username, setUsername] = useState(''); // This might not be used if you're not displaying the username in the navbar
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    const storedUsername = localStorage.getItem('username');
+    if (token && storedUsername) {
+      setIsLoggedIn(true);
+      setUsername(storedUsername);
+    }
+  }, []);
 
   return (
     <>
@@ -13,20 +63,27 @@ const Navbar = () => {
           <LogoImg src={Logo} alt="Logo" />
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
             <WebsiteName>Animal Adopter</WebsiteName>
-            <Bars />
+            <Bars onClick={() => setShowDropdown(!showDropdown)} style={{ cursor: 'pointer' }} />
             <div className="collapse navbar-collapse" id="navbarNav">
               <NavMenu style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <NavLink exact to="/" activeClassName="active" className="nav-link">Home</NavLink>
                 <NavLink to="/adopt" activeClassName="active" className="nav-link">Adopt</NavLink>
                 <NavLink to="/rehome" activeClassName="active" className="nav-link">Rehome</NavLink>
-                <FaUserCircle size="4em" onClick={() => setShowDropdown(!showDropdown)} style={{ position: 'absolute', right: '1%', top: '15%',color: 'white', cursor: 'pointer', marginLeft: '20px' }} />
+                <FaUserCircle size="4em" onClick={() => setShowDropdown(!showDropdown)} style={{ position: 'absolute', right: '1%', top: '15%', color: 'white', cursor: 'pointer', marginLeft: '20px' }} />
               </NavMenu>
               {showDropdown && (
-              <div style={{ position: 'absolute', right: '1%', top: '100%', backgroundColor: 'white', padding: '10px', borderRadius: '5px', boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)' }}>
-                <NavLink to="/login" activeClassName="active" className="nav-link">Login/Logout</NavLink>
-                <NavLink to="/profilePage" activeClassName="active" className="nav-link">Your Profile</NavLink>
-              </div>
-            )}
+                <div style={{ position: 'absolute', right: '1%', top: '100%', backgroundColor: 'white', padding: '10px', borderRadius: '5px', boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)' }}>
+                  {isLoggedIn && (
+                    <NavLink to="/login" activeClassName="active" className="nav-link">Logout</NavLink>
+                  )}
+                  {!isLoggedIn && (
+                    <NavLink to="/login" activeClassName="active" className="nav-link">Login</NavLink>
+                  )}
+                  {isLoggedIn && (
+                    <NavLink to="/profilePage" activeClassName="active" className="nav-link">Your Profile</NavLink>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/rehome.js
+++ b/frontend/src/pages/rehome.js
@@ -1,14 +1,50 @@
-import React from "react";
+import React, { useState, useEffect } from 'react';
 import FormComponent from '../components/FormComponent';
+import { NavLink } from "../components/Navbar/NavbarElements";
 
 import './rehome.css';
 
 const RehomeFormPage = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    setIsLoggedIn(!!token);
+
+    const handleStorageChange = (event) => {
+      if (event.key === 'token') {
+        setIsLoggedIn(!!localStorage.getItem('token'));
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, []);
+
   return (
     <div className="form-header" style={{ padding: '45px', textAlign: 'center' }}>
       <h1 style={{ marginBottom: '20px' }}>Add a Pet to be Adopted</h1>
-      <div style={{ maxWidth: '600px', margin: '0 auto' }}>
-        <FormComponent />
+      <div style={{ maxWidth: '600px', margin: '0 auto', textAlign: 'center' }}>
+        {isLoggedIn ? (
+          <FormComponent />
+        ) : (
+          <NavLink to="/login" activeClassName="active" className="nav-link" style={{
+            display: 'inline-block',
+            padding: '10px 20px',
+            margin: '20px 0',
+            backgroundColor: '#52987f',
+            color: 'white',
+            borderRadius: '5px',
+            textDecoration: 'none',
+            fontSize: '18px',
+            textAlign: 'center', // Center the text inside the button
+            border: 'none', // Remove any default border
+            cursor: 'pointer', // Make it look clickable
+            boxShadow: '0 2px 5px rgba(0,0,0,0.2)', // Optional: add a shadow for better button-like appearance
+            transition: 'all 0.3s' // Smooth transition for hover effects
+          }}>Login to add a pet</NavLink>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
If you are not logged in the navbar should only have one item, login. If you are logged in it should have profile page and logout. The navbar should close when you select an item now and should update without needed to refresh after you login/logout. When on the rehome page there should be a link to login if you are not logged in.